### PR TITLE
Add example cleaning long API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ yaml_cleaner = CleanYAMLSerializer()
 def clean_bad_word(request: dict, response: dict):
     response['body']['string'] = response['body']['string'].replace('shid', '')
 
+@clean_if(uri='https://example.com/api/returns_so_so_many_records')
+def clean_long_response(request: dict, response: dict):
+    response['body'] = "{'when all your test needs':'is this bit'}"
+
 yaml_cleaner.register_cleaner(clean_bad_word)
+yaml_cleaner.register_cleaner(clean_long_response)
 
 # Register an included function
 yaml_cleaner.register_cleaner(clean_token, uri='https://example.com/api/auth')


### PR DESCRIPTION
A use case we have encountered several times is when an API returns an enormous amount of information that leads to our cassette file being long and unreadable. 

I considered adding a dedicated example function (see #16), but it seems like a few lines in README covers this case pretty well.

Closes #16