### PR TITLE
Updated pattern - supports `contains`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,33 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This product is supported by University of Illinois Cybersecurity Development on a best-effort basis.
+
+As of the last update to this README, the expected End-of-Life and End-of-Support date of this product is October 2029.
+
+End-of-Life was decided upon based on these dependencies:
+
+    python 3.13 (October 2029)
+
+## [2.0.0]
+
+- Updated cleaner registration pattern
+- Update naming conventions for clarity
+
 ## [1.0.0]
+
 ### Added
+
 - Add support for VCR, pytest, and mypy
 - Add linting, formatting, and mypy to makefile
+
 ### Changed
+
 - Update cleaner functions
 - Update SECURITY.md
+
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ End-of-Life was decided upon based on these dependencies:
 - Update cleaner registration pattern
 - Update naming conventions for clarity
 
+### Removed
+
 ## [1.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ End-of-Life was decided upon based on these dependencies:
 
 ## [2.0.0]
 
-- Updated cleaner registration pattern
+### Added
+
+### Changed
+
+- Update cleaner registration pattern
 - Update naming conventions for clarity
 
 ## [1.0.0]

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
+# VCR Cleaner
+
 See `def test_with_vcr` in `tests/test_vcr_cleaner.py` for usage.
 
 ```python
 from vcr_cleaner.cleaners.jwt_token import clean_token
-from vcr_cleaner import clean_if, CleanYAMLSerializer
+from vcr_cleaner import CleanYAMLSerializer
 
 yaml_cleaner = CleanYAMLSerializer()
 
-# Register a custom function
-@clean_if(uri='https://example.com/api/foulmouth')
+# Register an included function
+yaml_cleaner.register_cleaner_if_uri_contains(clean_token, '/api/auth')
+
+# Define cleaner functions
 def clean_bad_word(request: dict, response: dict):
     response['body']['string'] = response['body']['string'].replace('shid', '')
 
-@clean_if(uri='https://example.com/api/returns_so_so_many_records')
 def clean_long_response(request: dict, response: dict):
     response['body'] = "{'when all your test needs':'is this bit'}"
 
-yaml_cleaner.register_cleaner(clean_bad_word)
-yaml_cleaner.register_cleaner(clean_long_response)
-
-# Register an included function
-yaml_cleaner.register_cleaner(clean_token, uri='https://example.com/api/auth')
+# Register custom cleaner functions
+yaml_cleaner.register_cleaner_if_uri_contains(clean_bad_word, '/api/foulmouth')
+yaml_cleaner.register_cleaner_if_uri_contains(clean_long_response, '/api/returns_so_so_many_records')
 
 my_vcr = vcr.VCR(
          cassette_library_dir='cassettes',

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -59,6 +59,7 @@ class CleanYAMLSerializer:
         uri_contains: str
     ):
         '''Apply registered cleaner only if URI contains the given text.'''
+
         @_apply_if_uri_contains(uri_contains=uri_contains)
         def decorated(*args, **kwargs):
             function(*args, **kwargs)

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -92,6 +92,7 @@ def _apply_if_uri_startswith(uri_starts: str):
     'example.com' will match 'example.com/robots.txt'
     'example.com' will match 'example.com/api/v1/users'
     '''
+
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -11,6 +11,10 @@ class CleanYAMLSerializer:
         self.cleaners = []
 
     def serialize(self, cassette: dict):
+        '''
+        Applies our cleaners while VCR.py serializes web traffic into a
+        cassette.
+        '''
         for interaction in cassette['interactions']:
             for cleaner in self.cleaners:
                 cleaner(interaction['request'], interaction['response'])
@@ -20,20 +24,101 @@ class CleanYAMLSerializer:
     def deserialize(cassette: str):
         return yamlserializer.deserialize(cassette)
 
-    def register_cleaner(self, function: Callable, uri=None):
-        if uri:
-            @clean_if(uri=uri)
-            def decorated(*args, **kwargs):
-                function(*args, **kwargs)
-        self.cleaners.append(decorated if uri else function)
+    def register_cleaner(self, function: Callable):
+        '''Apply this cleaner function to all cassette contents.'''
+        self.cleaners.append(function)
+
+    def register_cleaner_if_host_startswith(
+        self, function: Callable, hostname: str
+    ):
+        '''
+        Apply registered cleaner only if URI hostname before the first `/`
+        matches the given text.
+
+        'example.com' will match 'https://example.com/robots.txt'
+        'example.com' will match 'https://example.com/api/v1/users'
+        '''
+        @_apply_if_uri_startswith(uri_starts=hostname)
+        def decorated(*args, **kwargs):
+            function(*args, **kwargs)
+        self.register_cleaner(decorated)
+
+    def register_cleaner_if_path_endswith(self, function: Callable, path: str):
+        '''
+        Apply registered cleaner only if URI path after the first `/`
+        matches the given text.
+        '''
+        @_apply_if_uri_endswith(uri_ends=path)
+        def decorated(*args, **kwargs):
+            function(*args, **kwargs)
+        self.register_cleaner(decorated)
+
+    def register_cleaner_if_uri_contains(
+        self,
+        function: Callable,
+        uri_contains: str
+    ):
+        '''Apply registered cleaner only if URI contains the given text.'''
+        @_apply_if_uri_contains(uri_contains=uri_contains)
+        def decorated(*args, **kwargs):
+            function(*args, **kwargs)
+        self.register_cleaner(decorated)
 
 
-def clean_if(uri: str):
-    '''Decorates a cleaner method to make it apply only to the given URI'''
+def _apply_if_uri_contains(uri_contains: str):
+    '''Decorates a cleaner method to make it apply to any cassette interactions
+    where the URI contains the text passed to `uri_contains`.
+
+    Typically applied by the matching `register_cleaner_if...` function above.
+    '''
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):
-            if request['uri'] != uri:
+            if uri_contains not in request['uri']:
+                return
+            func(request, response)
+        return wrapper
+    return decorator
+
+
+def _apply_if_uri_startswith(uri_starts: str):
+    '''Decorates a cleaner method to make it apply to any cassette interactions
+    where the URI starts with the text passed to `uri_starts`.
+
+    Typically applied by the matching `register_cleaner_if...` function above.
+
+    'example.com' will match 'example.com/robots.txt'
+    'example.com' will match 'example.com/api/v1/users'
+    '''
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(request: dict, response: dict):
+            hostname = (
+                request['uri']
+                .lower()
+                .lstrip('https://')
+                .lstrip('http://')
+            )
+            if not hostname.startswith(uri_starts):
+                return
+            func(request, response)
+        return wrapper
+    return decorator
+
+
+def _apply_if_uri_endswith(uri_ends: str):
+    '''Decorates a cleaner method to make it apply to any cassette interactions
+    where the URI ends with the text passed to `uri_ends`.
+
+    Typically applied by the matching `register_cleaner_if...` function above.
+
+    'robots.txt' will match 'example.com/robots.txt'
+    'api/v1/users' will match 'example.com/api/v1/users'
+    '''
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def wrapper(request: dict, response: dict):
+            if not request['uri'].endswith(uri_ends):
                 return
             func(request, response)
         return wrapper

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -103,9 +103,8 @@ def _apply_if_uri_startswith(uri_starts: str):
                 .lstrip('https://')
                 .lstrip('http://')
             )
-            if not hostname.startswith(uri_starts):
-                return
-            func(request, response)
+            if hostname.startswith(uri_starts):
+                func(request, response)
         return wrapper
     return decorator
 

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -115,6 +115,7 @@ def _apply_if_uri_endswith(uri_ends: str):
     'robots.txt' will match 'example.com/robots.txt'
     'api/v1/users' will match 'example.com/api/v1/users'
     '''
+
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -49,6 +49,7 @@ class CleanYAMLSerializer:
         Apply registered cleaner only if URI path after the first `/`
         matches the given text.
         '''
+
         @_apply_if_uri_endswith(uri_ends=path)
         def decorated(*args, **kwargs):
             function(*args, **kwargs)

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -72,6 +72,7 @@ def _apply_if_uri_contains(uri_contains: str):
 
     Typically applied by the matching `register_cleaner_if...` function above.
     '''
+
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -38,6 +38,7 @@ class CleanYAMLSerializer:
         'example.com' will match 'https://example.com/robots.txt'
         'example.com' will match 'https://example.com/api/v1/users'
         '''
+
         @_apply_if_uri_startswith(uri_starts=hostname)
         def decorated(*args, **kwargs):
             function(*args, **kwargs)

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -122,9 +122,8 @@ def _apply_if_uri_endswith(uri_ends: str):
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):
-            if not request['uri'].endswith(uri_ends):
-                return
-            func(request, response)
+            if request['uri'].endswith(uri_ends):
+                func(request, response)
         return wrapper
     return decorator
 

--- a/src/vcr_cleaner/__init__.py
+++ b/src/vcr_cleaner/__init__.py
@@ -78,9 +78,8 @@ def _apply_if_uri_contains(uri_contains: str):
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(request: dict, response: dict):
-            if uri_contains not in request['uri']:
-                return
-            func(request, response)
+            if uri_contains in request['uri']:
+                func(request, response)
         return wrapper
     return decorator
 

--- a/tests/test_vcr_cleaner.py
+++ b/tests/test_vcr_cleaner.py
@@ -1,22 +1,34 @@
 import copy
 
-from vcr_cleaner import clean_if, CleanYAMLSerializer
+from vcr_cleaner import CleanYAMLSerializer
 
 
 def test_with_vcr():
-    @clean_if(uri='helloworld.com/robots.txt')
+
     def clean_robots(request: dict, response: dict):
         response['body']['string'] = \
-            response['body']['string'].replace('User-agent', 'TRON')
+            response['body']['string'].replace('User-agent', 'CLEAN_ROBOT')
+
+    def clean_all_md(request: dict, response: dict):
+        response['body']['string'] = \
+            response['body']['string'].replace('User-agent', 'CLEAN_MD')
 
     serializer = CleanYAMLSerializer()
-    serializer.register_cleaner(clean_robots)
-    tape = {'interactions': [{
-        'response': {'body': {"string": 'User-agent'}},
-        'request': {'uri': 'helloworld.com/robots.txt'},
-    }]}
+    serializer.register_cleaner_if_uri_contains(
+        clean_robots, uri_contains='/robots.txt'
+    )
+    serializer.register_cleaner_if_uri_contains(
+        clean_all_md, uri_contains='.md'
+    )
+    tape = {'interactions': [
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'helloworld.com/robots.txt'}, },
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'helloworld.com/file.md'}, }
+    ]}
     expected = copy.deepcopy(tape)
-    expected['interactions'][0]['response']['body']['string'] = "TRON"
+    expected['interactions'][0]['response']['body']['string'] = "CLEAN_ROBOT"
+    expected['interactions'][1]['response']['body']['string'] = "CLEAN_MD"
     result = serializer.deserialize(serializer.serialize(tape))
     assert result == expected
 
@@ -27,8 +39,10 @@ def test_register_uri():
         response['body']['string'] = 'TRON'
 
     serializer = CleanYAMLSerializer()
-    serializer.register_cleaner(undecorated_cleaner,
-                                uri='helloworld.com/robots.txt')
+    serializer.register_cleaner_if_uri_contains(
+        undecorated_cleaner,
+        uri_contains='/robots.txt'
+    )
 
     tape = {'interactions': [{
         'response': {'body': {"string": 'User-agent'}},
@@ -36,5 +50,104 @@ def test_register_uri():
     }]}
     expected = copy.deepcopy(tape)
     expected['interactions'][0]['response']['body']['string'] = "TRON"
+    result = serializer.deserialize(serializer.serialize(tape))
+    assert result == expected
+
+
+def test_register_cleaner_if_host_startswith():
+    def clean_host(request: dict, response: dict):
+        response['body']['string'] = 'CLEANED'
+
+    serializer = CleanYAMLSerializer()
+    serializer.register_cleaner_if_host_startswith(
+        clean_host,
+        hostname='example.com'
+    )
+
+    tape = {'interactions': [
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'example.com/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'https://example.com/api/v1/users'}},
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'http://example.com/robots.txt'}},
+    ]}
+    expected = copy.deepcopy(tape)
+    for interaction in expected['interactions']:
+        interaction['response']['body']['string'] = 'CLEANED'
+    result = serializer.deserialize(serializer.serialize(tape))
+    assert result == expected
+
+
+def test_register_cleaner_if_host_startswith_negative():
+    """Cleaner should NOT apply if hostname does not match exactly."""
+    def clean_host(request: dict, response: dict):
+        response['body']['string'] = 'CLEANED'
+
+    serializer = CleanYAMLSerializer()
+    serializer.register_cleaner_if_host_startswith(
+        clean_host,
+        hostname='example.com'
+    )
+
+    tape = {'interactions': [
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'notexample.com/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'sample.com/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'http://fooexample.com/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+            'request': {'uri': 'https://bar.com/api/v1/users'}},
+    ]}
+    expected = copy.deepcopy(tape)
+    result = serializer.deserialize(serializer.serialize(tape))
+    assert result == expected
+
+
+def test_register_cleaner_if_path_endswith():
+    def clean_path(request: dict, response: dict):
+        response['body']['string'] = 'CLEANED'
+
+    serializer = CleanYAMLSerializer()
+    serializer.register_cleaner_if_path_endswith(
+        clean_path,
+        path='robots.txt'
+    )
+
+    tape = {'interactions': [
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'example.com/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'http://other.com/api/robots.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'https://foo.com/robots.txt'}},
+    ]}
+    expected = copy.deepcopy(tape)
+    for interaction in expected['interactions']:
+        interaction['response']['body']['string'] = 'CLEANED'
+    result = serializer.deserialize(serializer.serialize(tape))
+    assert result == expected
+
+
+def test_register_cleaner_if_path_endswith_negative():
+    def clean_path(request: dict, response: dict):
+        response['body']['string'] = 'CLEANED'
+
+    serializer = CleanYAMLSerializer()
+    serializer.register_cleaner_if_path_endswith(
+        clean_path,
+        path='robots.txt'
+    )
+
+    tape = {'interactions': [
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'example.com/other.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'http://other.com/api/other.txt'}},
+        {'response': {'body': {"string": 'User-agent'}},
+         'request': {'uri': 'https://foo.com/other.txt'}},
+    ]}
+    expected = copy.deepcopy(tape)
     result = serializer.deserialize(serializer.serialize(tape))
     assert result == expected

--- a/tests/test_vcr_cleaner.py
+++ b/tests/test_vcr_cleaner.py
@@ -133,6 +133,7 @@ def test_register_cleaner_if_path_endswith():
 
 
 def test_register_cleaner_if_path_endswith_negative():
+
     def clean_path(request: dict, response: dict):
         response['body']['string'] = 'CLEANED'
 

--- a/tests/test_vcr_cleaner.py
+++ b/tests/test_vcr_cleaner.py
@@ -55,6 +55,7 @@ def test_register_uri():
 
 
 def test_register_cleaner_if_host_startswith():
+
     def clean_host(request: dict, response: dict):
         response['body']['string'] = 'CLEANED'
 

--- a/tests/test_vcr_cleaner.py
+++ b/tests/test_vcr_cleaner.py
@@ -81,6 +81,7 @@ def test_register_cleaner_if_host_startswith():
 
 def test_register_cleaner_if_host_startswith_negative():
     """Cleaner should NOT apply if hostname does not match exactly."""
+
     def clean_host(request: dict, response: dict):
         response['body']['string'] = 'CLEANED'
 


### PR DESCRIPTION
- Add `register_cleaner_if_host`, `register_cleaner_if_path`, `register_cleaner_if_uri_contains`
- Removes decorators from README - Python will still allow leveraging the internal decorators, but we found the `register` functions nicer to maintain. 
- Update recommended pattern from decorators to using register functions to encourage applying all rules cleaner in one place

Closes #30