### PR TITLE
Add uri_cleaner function (#28)

### DIFF
--- a/src/vcr_cleaner/cleaners/uri.py
+++ b/src/vcr_cleaner/cleaners/uri.py
@@ -1,0 +1,18 @@
+def clean_uri(old: str, new: str):
+    """Returns a cleaner function that replaces the request URI
+    string with all occurrences of substring old replaced by new.
+
+    from vcr_cleaner.cleaners import clean_uri
+    from vcr_cleaner import CleanYAMLSerializer as CYS
+
+    CYS.register_cleaner(clean_uri('example', 'CLEANED'))
+    """
+    def clean_uri(request: dict, response: dict):
+        if "uri" not in request.keys():
+            return request
+        request['uri'] = request['uri'].replace(old, new)
+        return request
+
+    clean_uri.__doc__ = f"Replaces the request URI string with all " \
+        f"occurrences of substring '{old}' replaced by '{new}'."
+    return clean_uri

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,0 +1,15 @@
+from vcr_cleaner.cleaners.uri import clean_uri
+
+
+def test_simple_clean_uri():
+    '''Test simple usage of clean_uri.'''
+    request = {
+        'uri': 'https://example.com'
+    }
+
+    cleaner = clean_uri('example', 'foo')
+    assert cleaner(request, None)['uri'] == 'https://foo.com'
+    assert cleaner.__name__ == "clean_uri"
+    assert str(cleaner.__doc__) != 'None'
+    assert 'example' in str(cleaner.__doc__)
+    assert 'foo' in str(cleaner.__doc__)


### PR DESCRIPTION
+ Add uri_cleaner function
+ Add a pattern for passing additional keyword arguments into cleaners

This is a draft because we are considering changing the pattern to have `register_cleaner` take a modified partial. We don't want to leave that burden on each developer, but we could provide a helper function for the most common case (folding in some keyword arguments).

Closes #28